### PR TITLE
Use new Google Photos API and remove unsupported functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ luac.out
 *.x86_64
 *.hex
 
+# Build
+build
+
+# Editor
+.idea

--- a/google-photo.lrplugin/GPhotoExportServiceProvider.lua
+++ b/google-photo.lrplugin/GPhotoExportServiceProvider.lua
@@ -117,6 +117,7 @@ function exportServiceProvider.startDialog( propertyTable )
 	updateCantExportBecause( propertyTable )
 
 	-- Make sure we're logged in.
+	logger:trace('call updateExportSettings in startDialog')
 	require 'GPhotoUser'
 	GPhotoUser.verifyLogin( propertyTable )
 end
@@ -154,11 +155,16 @@ end
 
 --------------------------------------------------------------------------------
 function exportServiceProvider.updateExportSettings( propertyTable )
+	propertyTable.access_token = ''
 	logger:trace('updateExportSettings')
+	logger:trace("access_token: '" .. propertyTable.access_token .. "'")
+	logger:trace("refresh_token: '" .. propertyTable.refresh_token .. "'")
+
 	local access_token = GPhotoAPI.refreshToken(propertyTable)
 	if access_token then
 		propertyTable.access_token = access_token
 	end
+	logger:trace('call updateExportSettings in updateExportSettings')
 	require 'GPhotoUser'
 	GPhotoUser.verifyLogin( propertyTable )
 
@@ -168,7 +174,7 @@ function exportServiceProvider.updateExportSettings( propertyTable )
 	else
 		prefs.counter = prefs.counter + 1
 	end
-	logger:info("counter:", prefs.counter)
+	logger:trace("counter:", prefs.counter)
 end
 
 --------------------------------------------------------------------------------

--- a/google-photo.lrplugin/GPhotoPublishSupport.lua
+++ b/google-photo.lrplugin/GPhotoPublishSupport.lua
@@ -33,7 +33,8 @@ publishServiceProvider.titleForGoToPublishedPhoto = "disable"
 function publishServiceProvider.deletePhotosFromPublishedCollection( publishSettings, arrayOfPhotoIds, deletedCallback )
 	logger:trace('deletePhotosFromPublishedCollection')
 	for i, photoId in ipairs( arrayOfPhotoIds ) do
-		GPhotoAPI.deletePhoto( publishSettings, { photoId = photoId, suppressErrorCodes = { [ 1 ] = true } } )
+		-- Google Photos does not provide a delete method yet.
+		-- GPhotoAPI.deletePhoto( publishSettings, { photoId = photoId, suppressErrorCodes = { [ 1 ] = true } } )
 		deletedCallback( photoId )
 	end
 end
@@ -41,13 +42,14 @@ end
 function publishServiceProvider.metadataThatTriggersRepublish( publishSettings )
 	logger:trace('metadataThatTriggersRepublish')
 
+	-- Google Photos API does not provide an update method
 	return {
 		default = false,
-		title = true,
-		caption = true,
-		keywords = true,
-		gps = true,
-		dateCreated = true,
+		title = false,
+		caption = false,
+		keywords = false,
+		gps = false,
+		dateCreated = false,
 
 		-- also (not used by Google Photo plug-in):
 			-- customMetadata = true,
@@ -68,10 +70,11 @@ end
 
 function publishServiceProvider.renamePublishedCollection( publishSettings, info )
 	logger:trace('renamePublishedCollection')
-	if info.remoteId then
-		GPhotoAPI.refreshToken(publishSettings)
-		GPhotoAPI.updateAlbum(publishSettings, info.remoteId, info.name)
-	end
+	-- Google Photos does not provide an update method yet.
+	--if info.remoteId then
+	--	GPhotoAPI.refreshToken(publishSettings)
+	--  GPhotoAPI.updateAlbum(publishSettings, info.remoteId, info.name)
+	--end
 end
 
 function publishServiceProvider.deletePublishedCollection( publishSettings, info )

--- a/google-photo.lrplugin/GPhotoUser.lua
+++ b/google-photo.lrplugin/GPhotoUser.lua
@@ -87,8 +87,9 @@ function GPhotoUser.login( propertyTable )
 	        propertyTable.access_token = auth.access_token
 	        propertyTable.refresh_token = auth.refresh_token
 		end
-		logger:info("access_token after: ", propertyTable.access_token)
-        GPhotoUser.updateUserStatusTextBindings( propertyTable )
+		logger:trace("access_token after: ", propertyTable.access_token)
+		logger:trace("refresh_token after: ", propertyTable.refresh_token)
+		GPhotoUser.updateUserStatusTextBindings( propertyTable )
 	end )
 end
 
@@ -101,15 +102,9 @@ function GPhotoUser.verifyLogin( propertyTable )
 		LrTasks.startAsyncTask( function()
 			logger:trace( "verifyLogin: updateStatus() is executing." )
 			if storedCredentialsAreValid( propertyTable ) then
-                if propertyTable.LR_editingExistingPublishConnection then
-					propertyTable.loginButtonTitle = LOC "$$$/GPhoto/LoginButton/LogInAgain=Log In"
-					propertyTable.loginButtonEnabled = false
-					propertyTable.validAccount = true
-                else
-					propertyTable.loginButtonTitle = LOC "$$$/GPhoto/LoginButton/LoggedIn=Switch Account"
-					propertyTable.loginButtonEnabled = true
-					propertyTable.validAccount = true
-                end
+				propertyTable.loginButtonTitle = LOC "$$$/GPhoto/LoginButton/LoggedIn=Switch Account"
+				propertyTable.loginButtonEnabled = true
+				propertyTable.validAccount = true
 			else
 				notLoggedIn( propertyTable )
 			end


### PR DESCRIPTION
Replace obsolete Picasa API with new [Google Photos API](https://developers.google.com/photos/).

Google Photos API is currently developer preview and supports only limited functions. I removed following functions for the time being.
* Update an album name
* Remove/Update photos 
  * If you modify a photo and try to re-publish it, both old and new ones are exist in a album.
  * Even if you remove a photo in Lightroom Collection and try to re-publish it, the photo remains in the album.



