### PR TITLE
Verify whether the response is empty

### DIFF
--- a/google-photo.lrplugin/GPhotoAPI.lua
+++ b/google-photo.lrplugin/GPhotoAPI.lua
@@ -377,6 +377,9 @@ function GPhotoAPI.listAlbums(propertyTable)
 		local json = require 'json'
 		local results = json.decode(result)
 		nextPageToken = results["nextPageToken"]
+		if not results.albums then
+			break
+		end
 		for i,v in ipairs(results.albums) do
 			albums[#albums+1] = v
 		end


### PR DESCRIPTION
Sometimes the List Albums API result is empty when last page and an error occurs.

```
07/25/2018 19:37:16 INFO	listAlbums nextPageToken: 	 AH_uQ4xxxxxxxxxx
07/25/2018 19:37:16 INFO	listAlbums url: 	 https://photoslibrary.googleapis.com/v1/albums?pageToken=AH_uQ4xxxxxxxxxx
07/25/2018 19:37:18 INFO	listAlbums result: 	 {
  "nextPageToken": "AH_uQ4xxxxxxxxxx"
}
```

This PR check whether the result is empty or not.
