### PR TITLE
Use your own API Key

### DIFF
--- a/google-photo.lrplugin/GPhotoExportServiceProvider.lua
+++ b/google-photo.lrplugin/GPhotoExportServiceProvider.lua
@@ -42,6 +42,8 @@ end
 exportServiceProvider.supportsIncrementalPublish = 'only'
 
 exportServiceProvider.exportPresetFields = {
+	{ key = 'consumer_key', default = '' },
+	{ key = 'consumer_secret', default = '' },
 	{ key = 'access_token', default = '' },
 	{ key = 'refresh_token', default = '' },
 }
@@ -149,6 +151,55 @@ function exportServiceProvider.sectionsForTopOfDialog( f, propertyTable )
 					end,
 				},
 			},
+
+			f:row {
+				spacing = f:control_spacing(),
+				f:separator {
+					fill_vertical = 0,
+					fill_horizontal = 1,
+				},
+			},
+
+			f:row {
+				spacing = f:control_spacing(),
+				f:static_text {
+					title = LOC "$$$/GPhoto/ExportDialog/ForDevelopers=for Developers (If you want to use your own API Key)",
+					alignment = 'left',
+					fill_horizontal = 1,
+				},
+			},
+
+			f:row {
+				spacing = f:control_spacing(),
+				f:static_text {
+					title = LOC "$$$/GPhoto/ExportDialog/ConsumerKey=Client ID",
+					alignment = 'right',
+					fill_horizontal = 1,
+				},
+				f:edit_field {
+					immediate = true, -- update value w/every keystroke
+					fill_horizontal = 1,
+					wraps = false,
+					value = bind 'consumer_key_input',
+				},
+			},
+
+			f:row {
+				spacing = f:control_spacing(),
+				f:static_text {
+					title = LOC "$$$/GPhoto/ExportDialog/ConsumerSecret=Client Secret",
+					alignment = 'right',
+					fill_horizontal = 1,
+				},
+				f:password_field {
+					immediate = true, -- update value w/every keystroke
+					fill_horizontal = 1,
+					wraps = false,
+					value = bind 'consumer_secret_input',
+				},
+			},
+
+
 		},
 	}
 end

--- a/google-photo.lrplugin/GPhotoUser.lua
+++ b/google-photo.lrplugin/GPhotoUser.lua
@@ -29,8 +29,10 @@ local function notLoggedIn( propertyTable )
 
 	propertyTable.username = nil
 	propertyTable.fullname = ''
-    propertyTable.access_token = nil
-    propertyTable.refresh_token = nil
+  propertyTable.consumer_key = ''
+  propertyTable.consumer_secret = ''
+  propertyTable.access_token = nil
+  propertyTable.refresh_token = nil
 
 	propertyTable.accountStatus = LOC "$$$/GPhoto/SignIn=Sign in with your Google account."
 	propertyTable.loginButtonTitle = LOC "$$$/GPhoto/LoginButton/NotLoggedIn=Log In"
@@ -55,6 +57,8 @@ function GPhotoUser.login( propertyTable )
 
 		propertyTable.accountStatus = LOC "$$$/GPhoto/AccountStatus/LoggingIn=Logging in..."
 		propertyTable.loginButtonEnabled = false
+		propertyTable.consumer_key = propertyTable.consumer_key_input
+		propertyTable.consumer_secret = propertyTable.consumer_secret_input
 
 		LrDialogs.attachErrorDialogToFunctionContext( context )
 
@@ -70,7 +74,7 @@ function GPhotoUser.login( propertyTable )
 		propertyTable.accountStatus = LOC "$$$/GPhoto/AccountStatus/WaitingForGPhoto=Waiting for response..."
 
 		require 'GPhotoAPI'
-        local auth = GPhotoAPI.login(context)
+        local auth = GPhotoAPI.login(context, propertyTable.consumer_key, propertyTable.consumer_secret)
 
 		-- If editing existing connection, make sure user didn't try to change user ID on us.
         --[[


### PR DESCRIPTION
This PR provides users the ability to use their API Key.
If user does not enter API Key, the built-in default key will be used as before.

![image](https://user-images.githubusercontent.com/855724/44458008-d0bd0880-a63f-11e8-8aa7-44035c5fd6c4.png)
