### PR TITLE
Add missing X-Goog-Upload-Protocol=raw header

### DIFF
--- a/google-photo.lrplugin/GPhotoAPI.lua
+++ b/google-photo.lrplugin/GPhotoAPI.lua
@@ -203,6 +203,7 @@ function GPhotoAPI.uploadPhoto( propertyTable, params )
 	local headers = auth_header(propertyTable)
 	headers[#headers+1] = { field = 'Content-Type', value = 'application/octet-stream'}
 	headers[#headers+1] = { field = 'X-Goog-Upload-File-Name', value = fileName }
+	headers[#headers+1] = { field = 'X-Goog-Upload-Protocol', value = 'raw' }
 
 	local image = LrFileUtils.readFile( filePath )
 	local resultRaw, hdrs
@@ -222,7 +223,7 @@ function GPhotoAPI.uploadPhoto( propertyTable, params )
 		albumId = params.albumId,
 		newMediaItems = {
 			{
-				description = "ITEM_DESCRIPTION",
+				description = "Lightroom Uploaded",
 	 			simpleMediaItem = {
 					uploadToken = uploadToken
 				}


### PR DESCRIPTION
This header is required for setting the file name correctly per Google's documentation:
https://developers.google.com/photos/library/guides/upload-media

Also, this commit replaces the default placeholder text to something bit more meaningful.

fixes #18 