### PR TITLE
Upload photo with title and description from metadata

### DIFF
--- a/google-photo.lrplugin/GPhotoAPI.lua
+++ b/google-photo.lrplugin/GPhotoAPI.lua
@@ -51,6 +51,30 @@ end
 
 --------------------------------------------------------------------------------
 
+local function isempty( s )
+  return s == nil or s == ''
+end
+
+--------------------------------------------------------------------------------
+
+local function createOneLineDescription( title, description, separator )
+	if(isempty( title ) and not isempty( description )) then
+		return description
+	end
+	
+	if(not isempty( title ) and isempty( description )) then
+		return title
+	end
+	
+	if( not isempty( title ) and not isempty( description )) then
+		return title .. separator .. description
+	end
+	
+	return nil
+end
+
+--------------------------------------------------------------------------------
+
 --[[ Some Handy Constants ]]--
 
 -- Cocaoa time of 0 is unix time 978307200
@@ -216,13 +240,13 @@ function GPhotoAPI.uploadPhoto( propertyTable, params )
 	end
 	-- Parse GPhoto response for photo ID.
 	local uploadToken = resultRaw
-
+	
 	local postUrlForMeta = 'https://photoslibrary.googleapis.com/v1/mediaItems:batchCreate'
 	local meta = {
 		albumId = params.albumId,
 		newMediaItems = {
 			{
-				description = "ITEM_DESCRIPTION",
+				description = createOneLineDescription( params.title, params.description, propertyTable.separator ),
 	 			simpleMediaItem = {
 					uploadToken = uploadToken
 				}

--- a/google-photo.lrplugin/GPhotoUser.lua
+++ b/google-photo.lrplugin/GPhotoUser.lua
@@ -29,10 +29,10 @@ local function notLoggedIn( propertyTable )
 
 	propertyTable.username = nil
 	propertyTable.fullname = ''
-  propertyTable.consumer_key = ''
-  propertyTable.consumer_secret = ''
-  propertyTable.access_token = nil
-  propertyTable.refresh_token = nil
+	propertyTable.consumer_key = ''
+	propertyTable.consumer_secret = ''
+	propertyTable.access_token = nil
+	propertyTable.refresh_token = nil
 
 	propertyTable.accountStatus = LOC "$$$/GPhoto/SignIn=Sign in with your Google account."
 	propertyTable.loginButtonTitle = LOC "$$$/GPhoto/LoginButton/NotLoggedIn=Log In"


### PR DESCRIPTION
I changed your great plugin so it does upload title and description from metadata correctly to google photos. If none is present it leaves it empty. Separator between title and description can be customized.